### PR TITLE
Fix mapping of MAV_STATE

### DIFF
--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -271,8 +271,11 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
                            : arm_status::NOT_ARMED;
 
         // Decode status flag
-        mav.stat = (hb.system_status == MAV_STATE_ACTIVE) ? status::ACTIVE
-                                                          : status::STANDBY;
+        mav.stat = (hb.system_status == MAV_STATE_ACTIVE ||
+                    hb.system_status == MAV_STATE_CRITICAL ||
+                    hb.system_status == MAV_STATE_EMERGENCY)
+                       ? status::ACTIVE
+                       : status::STANDBY;
         return;
     }
     case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {


### PR DESCRIPTION
closes #12

Previously, mavlink_vehicles was mapping the more specific mavlink MAV_STATE
enum to a more generic STATUS enum as follows:

MAV_STATE_UNINIT -> mavlink_vehicles::status::STANDBY
MAV_STATE_BOOT -> mavlink_vehicles::status::STANDBY
MAV_STATE_CALIBRATING -> mavlink_vehicles::status::STANDBY
MAV_STATE_ACTIVE -> mavlink_vehicles::status::ACTIVE
MAV_STATE_CRITICAL -> mavlink_vehicles::status::STANDBY
MAV_STATE_EMERGENCY -> mavlink_vehicles::status::STANDBY
MAV_STATE_POWEROFF -> mavlink_vehicles::status::STANDBY

This simplification has been placed taking in consideration only a specific use
case: determine whether the vehicle is already flying (ACTIVE) or not
(STANDBY). While testing It has been noted that the states STATE_CRITICAL and
STATE_EMERGENCY might also be set during flight, and so, those should also be
mapped to mavlink_vehicles::status::ACTIVE.

This is what this patch does:

MAV_STATE_UNINIT -> mavlink_vehicles::status::STANDBY
MAV_STATE_BOOT -> mavlink_vehicles::status::STANDBY
MAV_STATE_CALIBRATING -> mavlink_vehicles::status::STANDBY
MAV_STATE_ACTIVE -> mavlink_vehicles::status::ACTIVE
MAV_STATE_CRITICAL -> mavlink_vehicles::status::ACTIVE
MAV_STATE_EMERGENCY -> mavlink_vehicles::status::ACTIVE
MAV_STATE_POWEROFF -> mavlink_vehicles::status::STANDBY

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
