### PR TITLE
Implement immediate take-control

### DIFF
--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -547,6 +547,11 @@ gps_status mav_vehicle::get_gps_status() const
     return gps;
 }
 
+void mav_vehicle::take_control(bool take_control)
+{
+    this->is_our_control = take_control;
+}
+
 void mav_vehicle::send_heartbeat()
 {
     using namespace std::chrono;

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -154,6 +154,9 @@ class mav_vehicle
     void brake(bool autocontinue);
     bool is_brake_active() const;
 
+    // Be responsible for the autorotation of the vehicle.
+    void take_control(bool take_control);
+
   private:
     status stat;
     arm_status arm_stat;


### PR DESCRIPTION
Set is_our_control flag to make sure that this instance of mavlink_vehicle will
be in charge of autorotate.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
