### PR TITLE
Fix is_timedout()

### DIFF
--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -75,7 +75,7 @@ bool is_timedout(std::chrono::time_point<std::chrono::system_clock> timestamp,
 {
     using namespace std::chrono;
     return duration_cast<milliseconds>(system_clock::now() - timestamp)
-               .count() > timeout_ms;
+               .count() >= timeout_ms;
 }
 
 bool is_same_socket(sockaddr_storage &r1, sockaddr_storage &r2)


### PR DESCRIPTION
Closes #22

Consider timedout when `current_time - timestamp >= timeout` and not only when
`current_time - timestamp > timeout`.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
