### PR TITLE
PX4 integration

### DIFF
--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -41,6 +41,38 @@
 #define print_verbose(...) ;
 #endif
 
+enum PX4_CUSTOM_MAIN_MODE {
+	PX4_CUSTOM_MAIN_MODE_MANUAL = 1,
+	PX4_CUSTOM_MAIN_MODE_ALTCTL,
+	PX4_CUSTOM_MAIN_MODE_POSCTL,
+	PX4_CUSTOM_MAIN_MODE_AUTO,
+	PX4_CUSTOM_MAIN_MODE_ACRO,
+	PX4_CUSTOM_MAIN_MODE_OFFBOARD,
+	PX4_CUSTOM_MAIN_MODE_STABILIZED,
+	PX4_CUSTOM_MAIN_MODE_RATTITUDE
+};
+
+enum PX4_CUSTOM_SUB_MODE_AUTO {
+	PX4_CUSTOM_SUB_MODE_AUTO_READY = 1,
+	PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF,
+	PX4_CUSTOM_SUB_MODE_AUTO_LOITER,
+	PX4_CUSTOM_SUB_MODE_AUTO_MISSION,
+	PX4_CUSTOM_SUB_MODE_AUTO_RTL,
+	PX4_CUSTOM_SUB_MODE_AUTO_LAND,
+	PX4_CUSTOM_SUB_MODE_AUTO_RTGS,
+	PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET
+};
+
+union px4_custom_mode {
+	struct {
+		uint16_t reserved;
+		uint8_t main_mode;
+		uint8_t sub_mode;
+	};
+	uint32_t data;
+	float data_float;
+};
+
 namespace defaults
 {
 const uint8_t target_system_id = 1;
@@ -68,6 +100,7 @@ const uint16_t heartbeat = 1000;
 const uint16_t set_mode = 1000;
 const uint16_t takeoff = 1000;
 const uint16_t rotate = 200;
+const uint16_t detour = 200;
 }
 
 bool is_timedout(std::chrono::time_point<std::chrono::system_clock> timestamp,
@@ -246,23 +279,40 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
     case MAVLINK_MSG_ID_HEARTBEAT: {
         mavlink_heartbeat_t hb;
         mavlink_msg_heartbeat_decode(msg, &hb);
-
-        // Decode mode flag
-        // ArduCopter only supports custom_modes. The custom_mode value for
-        // each mode is described in ArduCopter's documentation.
         mav.base_mode = mode::OTHER;
 
-        if (!(hb.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED)) {
-            return;
+        print_verbose("Heartbeat received\n");
+
+        // Decode ArduPilot mode flag
+        if (mav.flight_stack_type == firmware_type::APM) {
+            if (!(hb.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED)) {
+                return;
+            }
+
+            switch (hb.custom_mode) {
+            case 3: // ArduCopter AUTO
+                mav.base_mode = mode::AUTO;
+                break;
+            case 4: // ArduCopter GUIDED
+                mav.base_mode = mode::GUIDED;
+                break;
+            }
         }
 
-        switch (hb.custom_mode) {
-        case 3: // ArduCopter AUTO
-            mav.base_mode = mode::AUTO;
-            break;
-        case 4: // ArduCopter GUIDED
-            mav.base_mode = mode::GUIDED;
-            break;
+        // Decode PX4 mode flag
+        if (mav.flight_stack_type == firmware_type::PX4) {
+            if (!(hb.base_mode & 157)) {
+                return;
+            }
+
+            union px4_custom_mode px4_mode;
+            px4_mode.data = hb.custom_mode;
+            if (px4_mode.main_mode == PX4_CUSTOM_MAIN_MODE_OFFBOARD) {
+                mav.base_mode = mode::GUIDED;
+            } else if (px4_mode.main_mode == PX4_CUSTOM_MAIN_MODE_AUTO &&
+                       px4_mode.sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_MISSION) {
+                mav.base_mode = mode::AUTO;
+            }
         }
 
         // Decode arm status flag
@@ -312,6 +362,7 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
         return;
     }
     case MAVLINK_MSG_ID_MISSION_ACK: {
+        print_verbose("MISSION ACK RECEIVED\n");
         mavlink_mission_ack_t ack;
         mavlink_msg_mission_ack_decode(msg, &ack);
 
@@ -708,8 +759,24 @@ void mav_vehicle::set_mode(mode m, int timeout)
         // a custom mode instead. GUIDED mode is defined as 4.
         mavlink_message_t mav_msg;
         mavlink_set_mode_t mav_cmd_set_mode;
-        mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-        mav_cmd_set_mode.custom_mode = 4; // mode::GUIDED == 4
+        mav_cmd_set_mode.target_system = defaults::target_system_id;
+
+        switch (this->flight_stack_type) {
+        case firmware_type::PX4:
+            union px4_custom_mode px4_mode;
+            px4_mode.data = 0;
+            px4_mode.main_mode = PX4_CUSTOM_MAIN_MODE_OFFBOARD;
+            px4_mode.sub_mode = 0;
+            mav_cmd_set_mode.custom_mode = px4_mode.data;
+            mav_cmd_set_mode.base_mode = 157;
+            break;
+        case firmware_type::APM:
+            mav_cmd_set_mode.custom_mode = 4;
+            mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+            break;
+        default:
+            break;
+        }
 
         // Encode and send
         uint8_t mav_data_buffer[defaults::send_buffer_len];
@@ -735,8 +802,24 @@ void mav_vehicle::set_mode(mode m, int timeout)
         // a custom mode instead. AUTO mode is defined as 3.
         mavlink_message_t mav_msg;
         mavlink_set_mode_t mav_cmd_set_mode;
-        mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-        mav_cmd_set_mode.custom_mode = 3;
+        mav_cmd_set_mode.target_system = defaults::target_system_id;
+
+        switch (this->flight_stack_type) {
+        case firmware_type::PX4:
+            union px4_custom_mode px4_mode;
+            px4_mode.data = 0;
+            px4_mode.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
+            px4_mode.sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
+            mav_cmd_set_mode.custom_mode = px4_mode.data;
+            mav_cmd_set_mode.base_mode = 157;
+            break;
+        case firmware_type::APM:
+            mav_cmd_set_mode.custom_mode = 3;
+            mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+            break;
+        default:
+            break;
+        }
 
         // Encode and send
         uint8_t mav_data_buffer[defaults::send_buffer_len];
@@ -762,8 +845,25 @@ void mav_vehicle::set_mode(mode m, int timeout)
         // a custom mode instead. BRAKE mode is defined as 17.
         mavlink_message_t mav_msg;
         mavlink_set_mode_t mav_cmd_set_mode;
-        mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-        mav_cmd_set_mode.custom_mode = 17;
+        mav_cmd_set_mode.target_system = defaults::target_system_id;
+
+        switch (this->flight_stack_type) {
+        case firmware_type::PX4:
+            union px4_custom_mode px4_mode;
+            px4_mode.data = 0;
+            px4_mode.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
+            px4_mode.sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+            mav_cmd_set_mode.custom_mode = px4_mode.data;
+            mav_cmd_set_mode.base_mode = 157;
+            break;
+        case firmware_type::APM:
+            mav_cmd_set_mode.custom_mode = 17;
+            mav_cmd_set_mode.base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+            break;
+        default:
+            break;
+        }
+
 
         // Encode and send
         uint8_t mav_data_buffer[defaults::send_buffer_len];
@@ -882,23 +982,10 @@ void mav_vehicle::rotate(double angle_rad, bool autocontinue)
 {
     // We have taken control
     this->is_our_control = true;
-
     print_verbose("Rotation command received\n");
-    cmd_custom cmd = cmd_custom::ROTATE;
 
-    // Check if cmd_custom::ROTATE has been sent recently
-    if (cmd_custom_timestamps.count(cmd) &&
-        !is_timedout(cmd_custom_timestamps[cmd],
-                     request_intervals_ms::rotate)) {
-        return;
-    }
-
-    // Make sure the value is in the interval [-360, +360]
-    angle_rad = std::fmod(angle_rad, 2*M_PI);
-    double angle_deg = math::rad2deg(angle_rad);
-
-    this->rotation_goal = std::fmod(
-        (this->get_attitude().yaw - angle_rad), (2 * M_PI));
+    this->rotation_goal =
+        std::fmod((this->get_attitude().yaw - angle_rad), (2 * M_PI));
 
     if (this->rotation_goal > M_PI) {
         this->rotation_goal = this->rotation_goal - 2 * M_PI;
@@ -906,17 +993,11 @@ void mav_vehicle::rotate(double angle_rad, bool autocontinue)
         this->rotation_goal = this->rotation_goal + 2 * M_PI;
     }
 
-    // We need to make sure mode is set as GUIDED in order to send the rotation
-    // command
-    set_mode(mode::GUIDED, 0);
-
-    // Send the rotation command immediately
-    send_cmd_long(MAV_CMD_CONDITION_YAW, fabs(angle_deg),
-                  defaults::lookat_rot_speed_degps, -copysign(1, angle_deg), 1,
-                  0, 0, 0, 0);
-
-    // Update timestamp
-    cmd_custom_timestamps[cmd] = std::chrono::system_clock::now();
+    if (this->flight_stack_type == firmware_type::PX4) {
+        this->set_yaw_target(this->rotation_goal, 0);
+    } else {
+        this->set_yaw_target(fmod(angle_rad, (2 * M_PI)), 0);
+    }
 
     // Check what we are doing, in order to the current action saved to
     // autocontinue.
@@ -966,11 +1047,13 @@ void mav_vehicle::send_mission_waypoint(global_pos_int wp, bool autorotate)
 
     print_verbose("New mission received\n");
 
-    // We need to toggle from AUTO to GUIDED in order to update the mission
-    // waypoints
-    set_mode(mode::GUIDED, 0);
+    // We need to toggle from AUTO to GUIDED in order to update ArduPilot
+    // mission waypoints.
+    if (this->flight_stack_type == firmware_type::APM) {
+        set_mode(mode::GUIDED, 0);
+    }
 
-    // Ardupilot reserves the first element of the mission commands list
+    // The flight stack reserves the first element of the mission commands list
     // (seq=0) to the home position. Sending a mission item with that sequence
     // number does not overwrite the home position. Ardupilot simply ignores
     // it. For that reason, the first waypoint (seq=0) must be a mock waypoint
@@ -979,8 +1062,8 @@ void mav_vehicle::send_mission_waypoint(global_pos_int wp, bool autorotate)
     this->mission_items_list.push_back(wp); // Mock waypoint. Will be ignored.
     this->mission_items_list.push_back(wp); // Real target waypoint.
 
-    // Send the mission_count command to Ardupilot so that it prepares to
-    // request the mission items one by one.
+    // Send the mission_count command to the flight stack so that it prepares
+    // to request the mission items one by one.
     send_mission_count(2);
 
     // Set mission mode as normal
@@ -1031,6 +1114,221 @@ void mav_vehicle::send_mission_waypoint(global_pos_int wp, uint16_t seq)
                                         &mav_msg, &mav_waypoint);
     int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
     send_data(mav_data_buffer, n);
+
+    print_verbose("MISSION ITEM SENT (%d)\n", seq);
+}
+
+void mav_vehicle::set_yaw_target(float yaw)
+{
+    set_yaw_target(yaw, request_intervals_ms::rotate);
+}
+
+void mav_vehicle::set_yaw_target(float yaw, int timeout)
+{
+    cmd_custom cmd = cmd_custom::ROTATE;
+
+    // Check if cmd_custom::ROTATE has been sent recently
+    if (cmd_custom_timestamps.count(cmd) &&
+        !is_timedout(cmd_custom_timestamps[cmd], timeout)) {
+        return;
+    }
+
+    switch (this->flight_stack_type) {
+    case firmware_type::PX4:{
+        mavlink_set_position_target_local_ned_t set_position;
+
+        // Set mavlink message timestamp
+        using namespace std::chrono;
+        set_position.time_boot_ms =
+            duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
+                .count();
+
+        // Set mavlink message attributes
+        set_position.target_system = defaults::target_system_id;
+        set_position.target_component = defaults::target_component_id;
+
+        // Set frame
+        set_position.coordinate_frame = MAV_FRAME_LOCAL_NED;
+
+        // Ignore all parameters except for yaw
+        set_position.type_mask = 0b0000100111111000;
+
+        // We need to send a position with the yaw for it to work properly
+        local_pos wp_ned = this->get_local_position_ned();
+
+        // Set coordinates in Degrees * 1e7 according to frame and message type
+        set_position.x = wp_ned.x;
+        set_position.y = wp_ned.y;
+        set_position.z = wp_ned.z;
+
+        set_position.vx = 0;
+        set_position.vy = 0;
+        set_position.vz = 0;
+
+        set_position.afx = 0;
+        set_position.afy = 0;
+        set_position.afz = 0;
+
+        set_position.yaw = yaw;
+        set_position.yaw_rate = 0;
+
+        // Encode and Send
+        mavlink_message_t mav_msg;
+        uint8_t mav_data_buffer[defaults::send_buffer_len];
+        mavlink_msg_set_position_target_local_ned_encode(
+            this->system_id, defaults::component_id, &mav_msg, &set_position);
+        int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
+        send_data(mav_data_buffer, n);
+
+        // PX4 mode needs to be set after the command
+        if (this->get_mode() != mode::GUIDED) {
+            set_mode(mode::GUIDED);
+        }
+        break;
+    }
+    case firmware_type::APM:{
+
+        // APM mode needs to be set before sending the command
+        if (this->get_mode() != mode::GUIDED) {
+            set_mode(mode::GUIDED);
+        }
+
+        // Send the rotation command immediately
+        double angle_deg = math::rad2deg(yaw);
+
+        printf("commanded_angle: %f\n", angle_deg);
+
+        send_cmd_long(MAV_CMD_CONDITION_YAW, fabs(angle_deg),
+                      defaults::lookat_rot_speed_degps, -copysign(1, angle_deg),
+                      1, 0, 0, 0, 0);
+        break;
+    }
+    default:
+        break;
+    }
+
+    // Update timestamp
+    cmd_custom_timestamps[cmd] = std::chrono::system_clock::now();
+}
+
+void mav_vehicle::set_position_target(global_pos_int wp)
+{
+    this->set_position_target(wp, request_intervals_ms::detour);
+}
+
+void mav_vehicle::set_position_target(global_pos_int wp, int timeout)
+{
+    local_pos local_pos_ned =
+        math::global_to_local_ned(wp, this->get_home_position_int());
+
+    switch (this->flight_stack_type) {
+    case firmware_type::PX4: {
+        cmd_custom cmd = cmd_custom::DETOUR;
+
+        // Check if command has been sent recently
+        if (cmd_custom_timestamps.count(cmd) &&
+            !is_timedout(cmd_custom_timestamps[cmd], timeout)) {
+            return;
+        }
+
+        mavlink_set_position_target_local_ned_t set_position;
+
+        // Set mavlink message timestamp
+        using namespace std::chrono;
+        set_position.time_boot_ms =
+            duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
+                .count();
+
+        // Set mavlink message attributes
+        set_position.target_system = defaults::target_system_id;
+        set_position.target_component = defaults::target_component_id;
+
+        // Set frame
+        set_position.coordinate_frame = MAV_FRAME_LOCAL_NED;
+
+        // Ignore all parameters except for x, y, z
+        set_position.type_mask = 0b0000110111111000;
+
+        // Set coordinates in Degrees * 1e7 according to frame and message type
+        set_position.x = local_pos_ned.x;
+        set_position.y = local_pos_ned.y;
+        set_position.z = local_pos_ned.z;
+
+        set_position.vx = 0;
+        set_position.vy = 0;
+        set_position.vz = 0;
+
+        set_position.afx = 0;
+        set_position.afy = 0;
+        set_position.afz = 0;
+
+        set_position.yaw = 0;
+        set_position.yaw_rate = 0;
+
+        // Encode and Send
+        mavlink_message_t mav_msg;
+        uint8_t mav_data_buffer[defaults::send_buffer_len];
+        mavlink_msg_set_position_target_local_ned_encode(
+            this->system_id, defaults::component_id, &mav_msg, &set_position);
+        int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
+        send_data(mav_data_buffer, n);
+
+        // PX4 mode needs to be set after the command
+        if (this->get_mode() != mode::GUIDED) {
+            set_mode(mode::GUIDED);
+        }
+        break;
+    }
+    case firmware_type::APM: {
+        mavlink_mission_item_t mav_waypoint;
+
+        // APM mode needs to be set before sending the command
+        if (this->get_mode() != mode::GUIDED) {
+            set_mode(mode::GUIDED);
+        }
+
+        // Set mavlink message attributes
+        mav_waypoint.command = MAV_CMD_NAV_WAYPOINT;
+        mav_waypoint.target_system = defaults::target_system_id;
+        mav_waypoint.target_component = defaults::target_component_id;
+
+        // Arducopter supports only MAV_FRAME_GLOBAL_RELATIVE_ALT.
+        mav_waypoint.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+
+        // Coordinates in floating-point degrees according to frame and msg type
+        mav_waypoint.x = double(wp.lat) / 1e7f;
+        mav_waypoint.y = double(wp.lon) / 1e7f;
+
+        // Relative alt. in floating-point meters according to frame and msg
+        // type
+        mav_waypoint.z = double(wp.alt - this->home.alt) / 1e3f;
+
+        // Too low altitudes are not allowed by ArduCopter because of possible
+        // crash landings.
+        mav_waypoint.z = fmax(0.1, mav_waypoint.z);
+
+        // Set params
+        mav_waypoint.seq = 0;    // Unused
+        mav_waypoint.param1 = 0; // Hold time in decimal seconds
+        mav_waypoint.param2 = defaults::waypoint_acceptance_radius_m;
+        mav_waypoint.param3 = 0;       // Radius in meters to pass through wp
+        mav_waypoint.param4 = 0;       // Desired yaw angle
+        mav_waypoint.current = 2;      // Must be set as 2 for GUIDED waypoint
+        mav_waypoint.autocontinue = 0; // Unused
+
+        // Encode and Send
+        mavlink_message_t mav_msg;
+        uint8_t mav_data_buffer[defaults::send_buffer_len];
+        mavlink_msg_mission_item_encode(this->system_id, defaults::component_id,
+                                        &mav_msg, &mav_waypoint);
+        int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
+        send_data(mav_data_buffer, n);
+
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 void mav_vehicle::brake(bool autocontinue)
@@ -1076,46 +1374,8 @@ void mav_vehicle::send_detour_waypoint(global_pos_int wp, bool autocontinue,
     // We have taken control
     this->is_our_control = true;
 
-    mavlink_mission_item_t mav_waypoint;
-
-    // Request change to guided mode
-    set_mode(mode::GUIDED, 0);
-
-    // Set mavlink message attributes
-    mav_waypoint.command = MAV_CMD_NAV_WAYPOINT;
-    mav_waypoint.target_system = defaults::target_system_id;
-    mav_waypoint.target_component = defaults::target_component_id;
-
-    // Arducopter supports only MAV_FRAME_GLOBAL_RELATIVE_ALT.
-    mav_waypoint.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
-
-    // Coordinates in floating-point degrees according to frame and msg type
-    mav_waypoint.x = double(wp.lat) / 1e7f;
-    mav_waypoint.y = double(wp.lon) / 1e7f;
-
-    // Relative alt. in floating-point meters according to frame and msg type
-    mav_waypoint.z = double(wp.alt - this->home.alt) / 1e3f;
-
-    // Too low altitudes are not allowed by ArduCopter because of possible
-    // crash landings.
-    mav_waypoint.z = fmax(0.1, mav_waypoint.z);
-
-    // Set params
-    mav_waypoint.seq = 0;    // Unused
-    mav_waypoint.param1 = 0; // Hold time in decimal seconds
-    mav_waypoint.param2 = defaults::waypoint_acceptance_radius_m;
-    mav_waypoint.param3 = 0;       // Radius in meters to pass through wp
-    mav_waypoint.param4 = 0;       // Desired yaw angle
-    mav_waypoint.current = 2;      // Must be set as 2 for GUIDED waypoint
-    mav_waypoint.autocontinue = 0; // Unused
-
-    // Encode and Send
-    mavlink_message_t mav_msg;
-    uint8_t mav_data_buffer[defaults::send_buffer_len];
-    mavlink_msg_mission_item_encode(this->system_id, defaults::component_id,
-                                    &mav_msg, &mav_waypoint);
-    int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
-    send_data(mav_data_buffer, n);
+    // Send detour waypoint throught set_position_target
+    this->set_position_target(wp, 0);
 
     // Store detour waypoint
     this->detour_waypoint = wp;
@@ -1124,6 +1384,9 @@ void mav_vehicle::send_detour_waypoint(global_pos_int wp, bool autocontinue,
 
     // Set detour as active
     this->mstatus = mission_status::DETOURING;
+
+    // Request change to GUIDED mode
+    set_mode(mode::GUIDED, 0);
 
     print_verbose("Detour started\n");
 }
@@ -1289,6 +1552,18 @@ void mav_vehicle::update()
         return;
     }
 
+    // If we are in a detour we need to keep sending the waypoint to maintain
+    // PX4 in offboard mode
+    if (is_detour_active() && this->flight_stack_type == firmware_type::PX4) {
+        this->set_position_target(this->detour_waypoint);
+    }
+
+    // If we are in rotation mode, we need to keep sending the attitude to
+    // maintain px4 in offboard mode
+    if (is_rotation_active() && this->flight_stack_type == firmware_type::PX4) {
+        this->set_yaw_target(this->rotation_goal);
+    }
+
     // Check if a detour has been finished in order to continue the mission
     if (is_detour_active() &&
         (fabs(math::dist(detour_waypoint, get_global_position_int())) <=
@@ -1303,7 +1578,9 @@ void mav_vehicle::update()
         // Get back to AUTO mode to continue the mission
         if (this->detour_waypoint_autocontinue) {
             this->is_our_control = true;
-            set_mode(mode::AUTO, 0);
+            this->set_mode(mode::AUTO, 0);
+        }else {
+           this->brake(false);
         }
     }
 
@@ -1348,6 +1625,8 @@ void mav_vehicle::update()
                 set_mode(mode::AUTO, 0);
                 break;
             }
+        } else {
+           this->brake(false);
         }
     }
 

--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -61,7 +61,8 @@ const int is_stopped_low_speed_min_time_ms = 500;
 
 namespace request_intervals_ms
 {
-const uint16_t request_mission_item = 300;
+const uint16_t request_mission_list = 300;
+const uint16_t request_mission_item = 0;
 const uint16_t home_position = 3000;
 const uint16_t arm_disarm = 1000;
 const uint16_t heartbeat = 1000;
@@ -362,6 +363,11 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
             return;
         }
 
+        // Ignore if we are not receiving a mission list
+        if(!mav.is_receiving_mission()) {
+            return;
+        }
+
         // Evaluate mission frame and store mission item position with global
         // coordinates
         switch (mission_item.frame) {
@@ -380,7 +386,7 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
         default: {
             // Other types of frames are not supported
             print_verbose("Received mission item with "
-                          "unsupported frame num: %d",
+                          "unsupported frame num: %d\n",
                           (int)mission_item.frame);
             return;
         }
@@ -390,12 +396,34 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
         global_mission_item.timestamp = std::chrono::system_clock::now();
         global_mission_item.is_new = true;
 
-        // Retrieve current mission item data converting from
-        // global-relative-alt to global
+        // Mission item received
+        print_verbose("Mission item received: %d\n", mission_item.seq);
+
+        // Store mission item on list
+        if (mav.mission_items_list_received.size() == mission_item.seq) {
+            mav.mission_items_list_received.push_back(global_mission_item);
+        }
+
+        // Request next mission item
+        if (mav.mission_items_list_received.size() <
+            mav.mission_items_list_received_size) {
+            mav.request_mission_item(mav.mission_items_list_received.size());
+        }
+
+        // Store current mission item if this is the one being received
         if (mav.mission_waypoint_id == mission_item.seq) {
             mav.mission_waypoint = global_mission_item;
             mav.mission_waypoint_outdated = false;
-            print_verbose("Mission waypoint updated\n");
+            print_verbose("Mission waypoint updated %d\n", mission_item.seq);
+        }
+
+        // Print message saying that the full mission has been updated and send
+        // mission ACK.
+        if (mav.mission_items_list_received.size() ==
+            mav.mission_items_list_received_size) {
+            mav.receiving_mission = false;
+            mav.send_mission_ack(MAV_MISSION_ACCEPTED);
+            print_verbose("Mission list updated\n");
         }
         return;
     }
@@ -409,6 +437,30 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
             command_ack.result == MAV_RESULT_ACCEPTED) {
             return;
         }
+    }
+    case MAVLINK_MSG_ID_MISSION_COUNT: {
+        mavlink_mission_count_t mission_count;
+        mavlink_msg_mission_count_decode(msg, &mission_count);
+
+        // Mission count has been received what means that someone has asked
+        // for the mission list. First we check if it refers to us.
+        if (mission_count.target_system != mav.system_id) {
+            return;
+        }
+
+        // Ignore if we are not requesting a mission
+        if (!mav.is_receiving_mission()) {
+            return;
+        }
+
+        print_verbose("Mission count received: %d\n", mission_count.count);
+
+        // Request the mission waypoints one by one.
+        mav.mission_items_list_received.reserve(mission_count.count);
+        mav.mission_items_list_received.clear();
+        mav.mission_items_list_received_size = mission_count.count;
+        mav.request_mission_item(0);
+        return;
     }
     }
 }
@@ -543,6 +595,11 @@ bool mav_vehicle::is_detour_active() const
 bool mav_vehicle::is_sending_mission() const
 {
     return this->sending_mission;
+}
+
+bool mav_vehicle::is_receiving_mission() const
+{
+    return this->receiving_mission;
 }
 
 gps_status mav_vehicle::get_gps_status() const
@@ -712,11 +769,45 @@ void mav_vehicle::set_mode(mode m, int timeout)
     }
 }
 
+void mav_vehicle::request_mission_list()
+{
+    cmd_custom cmd = cmd_custom::REQUEST_MISSION_LIST;
+
+    // Check if the command has been sent recently
+    if (cmd_custom_timestamps.count(cmd) &&
+        !is_timedout(cmd_custom_timestamps[cmd],
+                     request_intervals_ms::request_mission_list)) {
+        return;
+    }
+
+    // Generate mission request list mavlink message
+    mavlink_message_t mav_msg;
+    mavlink_mission_request_list_t mav_mission_request;
+    mav_mission_request.target_system = defaults::target_system_id;
+    mav_mission_request.target_component = defaults::target_component_id;
+
+    // Encode and send
+    uint8_t mav_data_buffer[defaults::send_buffer_len];
+    mavlink_msg_mission_request_list_encode(this->system_id,
+                                            defaults::component_id, &mav_msg,
+                                            &mav_mission_request);
+    int n = mavlink_msg_to_send_buffer(mav_data_buffer, &mav_msg);
+    if (send_data(mav_data_buffer, n) == -1) {
+        std::perror("Error requesting mission list");
+    }
+
+    // Update timestamp
+    cmd_custom_timestamps[cmd] = std::chrono::system_clock::now();
+
+    this->receiving_mission = true;
+    print_verbose("Mission list requested\n");
+}
+
 void mav_vehicle::request_mission_item(uint16_t item_id)
 {
     cmd_custom cmd = cmd_custom::REQUEST_MISSION_ITEM;
 
-    // Check if cmd_custom::SET_MODE has been sent recently
+    // Check if cmd_custom has been sent recently
     if (cmd_custom_timestamps.count(cmd) &&
         !is_timedout(cmd_custom_timestamps[cmd],
                      request_intervals_ms::request_mission_item)) {
@@ -743,7 +834,7 @@ void mav_vehicle::request_mission_item(uint16_t item_id)
     // Update timestamp
     cmd_custom_timestamps[cmd] = std::chrono::system_clock::now();
 
-    print_verbose("Mission waypoint requested\n");
+    print_verbose("Mission waypoint requested %d\n", item_id);
 }
 
 void mav_vehicle::arm_throttle()
@@ -1167,7 +1258,7 @@ void mav_vehicle::update()
     // Check if mission has changed
     if (get_home_position_int().is_initialized() &&
         this->mission_waypoint_outdated) {
-        request_mission_item(this->mission_waypoint_id);
+        request_mission_list();
     }
 
     // Perform the next steps only if we are in control and if the vehicle is ready

--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -75,7 +75,7 @@ bool is_timedout(std::chrono::time_point<std::chrono::system_clock> timestamp,
 {
     using namespace std::chrono;
     return duration_cast<milliseconds>(system_clock::now() - timestamp)
-               .count() > timeout_ms;
+               .count() >= timeout_ms;
 }
 
 bool is_same_socket(sockaddr_storage &r1, sockaddr_storage &r2)

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -74,6 +74,7 @@ enum class cmd_custom {
     SET_MODE_AUTO,
     SET_MODE_BRAKE,
     REQUEST_MISSION_ITEM,
+    REQUEST_MISSION_LIST,
     ROTATE
 };
 
@@ -125,7 +126,7 @@ class mav_vehicle
     void arm_throttle();
     void send_heartbeat();
     void set_mode(mode m);
-    void request_mission_item(uint16_t item_id);
+    void request_mission_list();
 
     // Command the vehicle to immediately stop and rotate before moving to the
     // next detour or mission waypoint.
@@ -148,6 +149,7 @@ class mav_vehicle
                                bool autorotate = false);
     void send_mission_waypoint(global_pos_int global, bool autorotate = false);
     bool is_sending_mission() const;
+    bool is_receiving_mission() const;
 
     // Command the vehicle to brake immediately. The vehicle automatically
     // continues the mission after achieving v=0 if autocontinue is true.
@@ -175,6 +177,10 @@ class mav_vehicle
 
     std::vector<global_pos_int> mission_items_list;
     bool sending_mission = false;
+
+    bool receiving_mission = false;
+    unsigned int mission_items_list_received_size = 0;
+    std::vector<global_pos_int> mission_items_list_received;
 
     mission_status mstatus = mission_status::NORMAL;
 
@@ -215,6 +221,7 @@ class mav_vehicle
     void send_mission_ack(uint8_t type);
     void set_mode(mode m, int timeout);
     void send_mission_count(int n);
+    void request_mission_item(uint16_t item_id);
 
     friend class msghandler;
 };

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -68,6 +68,8 @@ enum class arm_status { ARMED, NOT_ARMED };
 
 enum class gps_status { NO_FIX, FIX_2D_PLUS };
 
+enum class firmware_type { APM, PX4 };
+
 enum class cmd_custom {
     HEARTBEAT,
     SET_MODE_GUIDED,
@@ -75,7 +77,8 @@ enum class cmd_custom {
     SET_MODE_BRAKE,
     REQUEST_MISSION_ITEM,
     REQUEST_MISSION_LIST,
-    ROTATE
+    ROTATE,
+    DETOUR
 };
 
 enum class mission_status {
@@ -200,6 +203,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
+    firmware_type flight_stack_type = firmware_type::APM;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};
@@ -224,6 +228,10 @@ class mav_vehicle
     void set_mode(mode m, int timeout);
     void send_mission_count(int n);
     void request_mission_item(uint16_t item_id);
+    void set_position_target(global_pos_int wp, int timeout);
+    void set_position_target(global_pos_int wp);
+    void set_yaw_target(float yaw, int timeout);
+    void set_yaw_target(float yaw);
 
     friend class msghandler;
 };

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -104,6 +104,7 @@ class mav_vehicle
 {
   public:
     mav_vehicle(int socket_fd);
+    mav_vehicle(int socket_fd, uint8_t sysid);
     ~mav_vehicle();
 
     void update();
@@ -207,6 +208,7 @@ class mav_vehicle
         remote_last_response_time = std::chrono::system_clock::from_time_t(0);
     bool remote_responding = false;
     bool is_remote_responding() const;
+    bool check_socket();
 
     std::unordered_map<int, std::chrono::time_point<std::chrono::system_clock>>
         cmd_long_timestamps;

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -62,7 +62,7 @@ struct local_pos : state_variable {
 
 enum class status { STANDBY, ACTIVE };
 
-enum class mode { GUIDED, AUTO, BRAKE, OTHER };
+enum class mode { GUIDED, AUTO, BRAKE, OTHER, TAKEOFF };
 
 enum class arm_status { ARMED, NOT_ARMED };
 
@@ -75,6 +75,7 @@ enum class cmd_custom {
     SET_MODE_GUIDED,
     SET_MODE_AUTO,
     SET_MODE_BRAKE,
+    SET_MODE_TAKEOFF,
     REQUEST_MISSION_ITEM,
     REQUEST_MISSION_LIST,
     ROTATE,
@@ -127,7 +128,7 @@ class mav_vehicle
     global_pos_int get_detour_waypoint();
 
     void takeoff();
-    void arm_throttle();
+    void arm_throttle(bool arm_disarm = true);
     void send_heartbeat();
     void set_mode(mode m);
     void request_mission_list();
@@ -203,7 +204,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
-    firmware_type flight_stack_type = firmware_type::APM;
+    firmware_type flight_stack_type = firmware_type::PX4;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};


### PR DESCRIPTION
This Pull Request integrates PX4 specific modes and commands into mavlink_vehicles and also implement some other general changes. The commits specifically related to PX4 are prefixed with PX4.

Currently, the flight stack (PX4 or APM-ardupilot) needs to be selected statically into mavlink_vehicles.hh, but a commit that implements the auto-detection of the flight stack will be submitted soon.
