### PR TITLE
PX4 integration - 2

### DIFF
--- a/mavlink_vehicles/apm.hh
+++ b/mavlink_vehicles/apm.hh
@@ -1,0 +1,24 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+
+enum APM_CUSTOM_MODE {
+    APM_CUSTOM_MODE_GUIDED = 4,
+    APM_CUSTOM_MODE_AUTO = 3,
+    APM_CUSTOM_MODE_BRAKE = 17
+};
+

--- a/mavlink_vehicles/mavlink_vehicles.cc
+++ b/mavlink_vehicles/mavlink_vehicles.cc
@@ -268,6 +268,19 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
 
         print_verbose("Heartbeat received\n");
 
+        // Detect flight stack
+        switch (hb.autopilot) {
+        case MAV_AUTOPILOT_ARDUPILOTMEGA:
+            mav.flight_stack_type = firmware_type::APM;
+            break;
+        case MAV_AUTOPILOT_PX4:
+            mav.flight_stack_type = firmware_type::PX4;
+            break;
+        default:
+            mav.flight_stack_type = firmware_type::UNKNOWN;
+            break;
+        }
+
         // Decode ArduPilot mode flag
         if (mav.flight_stack_type == firmware_type::APM) {
             if (!(hb.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED)) {

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -68,6 +68,8 @@ enum class arm_status { ARMED, NOT_ARMED };
 
 enum class gps_status { NO_FIX, FIX_2D_PLUS };
 
+enum class firmware_type { APM, PX4 };
+
 enum class cmd_custom {
     HEARTBEAT,
     SET_MODE_GUIDED,
@@ -75,7 +77,8 @@ enum class cmd_custom {
     SET_MODE_BRAKE,
     REQUEST_MISSION_ITEM,
     REQUEST_MISSION_LIST,
-    ROTATE
+    ROTATE,
+    DETOUR
 };
 
 enum class mission_status {
@@ -200,6 +203,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
+    firmware_type flight_stack_type = firmware_type::APM;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};
@@ -223,6 +227,10 @@ class mav_vehicle
     void set_mode(mode m, int timeout);
     void send_mission_count(int n);
     void request_mission_item(uint16_t item_id);
+    void set_position_target(global_pos_int wp, int timeout);
+    void set_position_target(global_pos_int wp);
+    void set_yaw_target(float yaw, int timeout);
+    void set_yaw_target(float yaw);
 
     friend class msghandler;
 };

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -68,7 +68,7 @@ enum class arm_status { ARMED, NOT_ARMED };
 
 enum class gps_status { NO_FIX, FIX_2D_PLUS };
 
-enum class firmware_type { APM, PX4 };
+enum class firmware_type { APM, PX4, UNKNOWN };
 
 enum class cmd_custom {
     HEARTBEAT,
@@ -204,7 +204,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
-    firmware_type flight_stack_type = firmware_type::PX4;
+    firmware_type flight_stack_type = firmware_type::UNKNOWN;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -68,7 +68,7 @@ enum class arm_status { ARMED, NOT_ARMED };
 
 enum class gps_status { NO_FIX, FIX_2D_PLUS };
 
-enum class firmware_type { APM, PX4, UNKNOWN };
+enum class autopilot_type { APM, PX4, UNKNOWN };
 
 enum class cmd_custom {
     HEARTBEAT,
@@ -82,12 +82,7 @@ enum class cmd_custom {
     DETOUR
 };
 
-enum class mission_status {
-    BRAKING,
-    DETOURING,
-    ROTATING,
-    NORMAL
-};
+enum class mission_status { BRAKING, DETOURING, ROTATING, NORMAL };
 
 class msghandler;
 
@@ -204,7 +199,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
-    firmware_type flight_stack_type = firmware_type::UNKNOWN;
+    autopilot_type autopilot = autopilot_type::UNKNOWN;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -62,7 +62,7 @@ struct local_pos : state_variable {
 
 enum class status { STANDBY, ACTIVE };
 
-enum class mode { GUIDED, AUTO, BRAKE, OTHER };
+enum class mode { GUIDED, AUTO, BRAKE, OTHER, TAKEOFF };
 
 enum class arm_status { ARMED, NOT_ARMED };
 
@@ -75,6 +75,7 @@ enum class cmd_custom {
     SET_MODE_GUIDED,
     SET_MODE_AUTO,
     SET_MODE_BRAKE,
+    SET_MODE_TAKEOFF,
     REQUEST_MISSION_ITEM,
     REQUEST_MISSION_LIST,
     ROTATE,
@@ -127,7 +128,7 @@ class mav_vehicle
     global_pos_int get_detour_waypoint();
 
     void takeoff();
-    void arm_throttle();
+    void arm_throttle(bool arm_disarm = true);
     void send_heartbeat();
     void set_mode(mode m);
     void request_mission_list();
@@ -203,7 +204,7 @@ class mav_vehicle
         std::chrono::system_clock::from_time_t(0);
     bool is_stopped();
 
-    firmware_type flight_stack_type = firmware_type::APM;
+    firmware_type flight_stack_type = firmware_type::PX4;
     uint8_t system_id = 0;
     int sock = 0;
     struct sockaddr_storage remote_addr = {0};

--- a/mavlink_vehicles/px4.hh
+++ b/mavlink_vehicles/px4.hh
@@ -1,0 +1,50 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+
+enum PX4_CUSTOM_MAIN_MODE {
+    PX4_CUSTOM_MAIN_MODE_MANUAL = 1,
+    PX4_CUSTOM_MAIN_MODE_ALTCTL,
+    PX4_CUSTOM_MAIN_MODE_POSCTL,
+    PX4_CUSTOM_MAIN_MODE_AUTO,
+    PX4_CUSTOM_MAIN_MODE_ACRO,
+    PX4_CUSTOM_MAIN_MODE_OFFBOARD,
+    PX4_CUSTOM_MAIN_MODE_STABILIZED,
+    PX4_CUSTOM_MAIN_MODE_RATTITUDE
+};
+
+enum PX4_CUSTOM_SUB_MODE_AUTO {
+    PX4_CUSTOM_SUB_MODE_AUTO_READY = 1,
+    PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF,
+    PX4_CUSTOM_SUB_MODE_AUTO_LOITER,
+    PX4_CUSTOM_SUB_MODE_AUTO_MISSION,
+    PX4_CUSTOM_SUB_MODE_AUTO_RTL,
+    PX4_CUSTOM_SUB_MODE_AUTO_LAND,
+    PX4_CUSTOM_SUB_MODE_AUTO_RTGS,
+    PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET
+};
+
+union px4_custom_mode {
+    struct {
+        uint16_t reserved;
+        uint8_t main_mode;
+        uint8_t sub_mode;
+    };
+    uint32_t data;
+    float data_float;
+};
+


### PR DESCRIPTION
This Pull Request integrates PX4 specific modes and commands into mavlink_vehicles.

Currently, the flight stack (PX4 or APM-ardupilot) needs to be selected statically into mavlink_vehicles.hh, but a commit that implements the auto-detection of the flight stack will be submitted soon.

Reviewed version of #28 
