### PR TITLE
Add support for g++-5

### DIFF
--- a/mavlink_vehicles/CMakeLists.txt
+++ b/mavlink_vehicles/CMakeLists.txt
@@ -5,7 +5,7 @@ find_program(PYTHON python)
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 
-set(CUSTOM_COMPILE_FLAGS "${CUSTOM_COMPILE_FLAGS} -Wall -pthread")
+set(CUSTOM_COMPILE_FLAGS "${CUSTOM_COMPILE_FLAGS} -Wall -pthread -std=c++11")
 set(LDFLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 set(CFLAGS "${CFLAGS} -fstack-protector-all -fPIE -fPIC -O2 -D_FORTIFY_SOURCE=2")
 set(CFLAGS "${CFLAGS} -Wformat -Wformat-security")

--- a/mavlink_vehicles/mavlink_vehicles.hh
+++ b/mavlink_vehicles/mavlink_vehicles.hh
@@ -209,10 +209,19 @@ class mav_vehicle
     bool remote_responding = false;
     bool is_remote_responding() const;
 
+    struct EnumHash
+    {
+        template <typename T> std::size_t operator()(T t) const
+        {
+            return static_cast<std::size_t>(t);
+        }
+    };
+
     std::unordered_map<int, std::chrono::time_point<std::chrono::system_clock>>
         cmd_long_timestamps;
     std::unordered_map<cmd_custom,
-                       std::chrono::time_point<std::chrono::system_clock>>
+                       std::chrono::time_point<std::chrono::system_clock>,
+                       EnumHash>
         cmd_custom_timestamps;
 
     ssize_t send_data(uint8_t *data, size_t len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
-set(CUSTOM_COMPILE_FLAGS "${CUSTOM_COMPILE_FLAGS} -Wall")
+set(CUSTOM_COMPILE_FLAGS "${CUSTOM_COMPILE_FLAGS} -Wall -std=c++11")
 set(LDFLAGS "${LDFLAGS} -z noexecstack -z relro -z now")
 set(CFLAGS "${CFLAGS} -fstack-protector-all -fPIE -fPIC -O2 -D_FORTIFY_SOURCE=2")
 set(CFLAGS "${CFLAGS} -Wformat -Wformat-security")


### PR DESCRIPTION
Before g++-6 there was no implicit cast for enums, so they couldn't be
used as unnordered_map keys unless a hash function was provided. Also,
we need -std=c++11 as compiler parameter since it was only made default
with g++-6.
