### PR TITLE
Replace include_directories with target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,12 @@ set(ADDITIONAL_COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS} -Wformat -Wformat-secu
 set(ADDITIONAL_COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS} -Wall -std=c++11")
 set(ADDITIONAL_LINK_FLAGS "-z noexecstack -z relro -z now")
 
-# Include directories
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${MAVLINK_INCLUDE_DIRS}/v1.0/autoquad)
-
 # Build Library
 add_library(mavlink_vehicles src/mavlink_vehicles.cc)
 set_target_properties(mavlink_vehicles PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS}")
+target_include_directories(mavlink_vehicles PUBLIC
+                           "${CMAKE_CURRENT_SOURCE_DIR}/src"
+                           "${MAVLINK_INCLUDE_DIRS}/v1.0/autoquad")
 
 # Build Tests
 add_executable(tests tests/tests.cc)


### PR DESCRIPTION
Cmake include_directories() does not propagate up, what means that any project
that includes this project as a subdirectory will need to know the exact
location of our headers if it wants to use them. As a result, parent projects
will eventually need to make changes to their include paths if for some reason
we change something in ours, besides having to keep long names in their
\#include directives or include_directories().

For example, the following line would be needed in orther include
mavlink_vehicles.hh in the source code of a parent project:

    ```
    #include "mavlink_vehicles/src/mavlink_vehicles.hh"
    ```

By using target_include_directories(), cmake deals with it transparently when a
target of a parent project links to our library. Then, the source code of that
target would need simply to add the following line to include our headers:

    ```
    #include "mavlink_vehicles.hh"
    ```

Signed-off-by: Guilherme Campos Camargo <guilherme.campos.camargo@intel.com>