### PR TITLE
Build: Add support to Yocto SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
-cmake_minimum_required(VERSION 2.8.12.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-# Find required packages
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(MAVLINK REQUIRED mavlink)
+# Support Yocto SDK
+if(DEFINED ENV{SDKTARGETSYSROOT})
+    message(STATUS "Using Yocto Environment to build")
+    set(CMAKE_FIND_ROOT_PATH $ENV{SDKTARGETSYSROOT})
+endif()
+
+find_path(MAVLINK_INCLUDE_DIR "mavlink.h"
+    PATH_SUFFIXES "autoquad"
+                  "v1.0/autoquad"
+                  "mavlink/v1.0/autoquad")
 
 # Generate documentation
 find_package(Doxygen)
@@ -38,7 +45,7 @@ add_library(mavlink_vehicles src/mavlink_vehicles.cc)
 set_target_properties(mavlink_vehicles PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS}")
 target_include_directories(mavlink_vehicles PUBLIC
                            "${CMAKE_CURRENT_SOURCE_DIR}/src"
-                           "${MAVLINK_INCLUDE_DIRS}/v1.0/autoquad")
+                           "${MAVLINK_INCLUDE_DIR}")
 
 # Build Tests
 add_executable(tests tests/tests.cc)


### PR DESCRIPTION
This patch add support to the Yocto SDK by properly passing sysroot
information to build the project.

Sadly, besides what is said in CMake documentation, FindPkgConfig
don't deal very well with "CMAKE_FIND_ROOT_PATH" + "CMAKE_PREFIX_PATH"
combo. Luckily for us, find_*() commands does (from 3.1 onwards)!

So now MavLink is found by find_path(), taking advantage of the fact
that its headers only library.

Now, to cross-compile this project against a system that doesn't provide
Mavlink headers, one just have to set CMAKE_PREFIX_PATH to where those
headers can be found.