### PR TITLE
build: Make out of source build mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
+# Make out of source builds mandatory
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
 # Support Yocto SDK
 if(DEFINED ENV{SDKTARGETSYSROOT})
     message(STATUS "Using Yocto Environment to build")


### PR DESCRIPTION
Building mavlink-vehicles in source produces an error due to a conflict
between tests binary and tests directory. The recommendation is to
build it out of source and to avoid future issues, this patch makes
out of source builds mandatory, i.e. in source builds will be aborted
right after cmake execution.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>