### PR TITLE
Workarount to successfully receive mission

### DIFF
--- a/src/mavlink_vehicles.cc
+++ b/src/mavlink_vehicles.cc
@@ -427,6 +427,8 @@ void msghandler::handle(mav_vehicle &mav, const mavlink_message_t *msg)
             global_mission_item.alt = mission_item.z * 1e3 + mav.home.alt;
             break;
         }
+        case MAV_FRAME_MISSION:
+            break;
         default: {
             // Other types of frames are not supported
             print_verbose("Received mission item with "


### PR DESCRIPTION
When MAV_FRAME_MISSION mission items where found we were getting stuck.
The code needs to be re-worked properly to deal with this case, but for
now this solves the problem for our use cases.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>